### PR TITLE
Unpin from requests 2.21.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
 
     ],
     install_requires=[
-        'requests == 2.21.0',
+        'requests ~= 2.2',
         'Click==7.0',
         'phonenumbers'
 


### PR DESCRIPTION
Version 2.21.0 was released in 2018. Pinning the package to it creates dependency issues since other packages, such as `urllib3`, can't be updated past a certain version due to this constraint. 

This PR opens this up to 2.2x since that picks newer versions but also steers clear of major updates. As of this writing, the latest version is 2.28.1